### PR TITLE
1.4.0

### DIFF
--- a/lib/converters.js
+++ b/lib/converters.js
@@ -39,7 +39,6 @@ converters.blockquote = function (input, json2md) {
 
 converters.img = function (input, json2md) {
     if (Array.isArray(input)) {
-        debugger
         return json2md(input, "", "img");
     }
     if (typeof input === "string") {

--- a/lib/converters.js
+++ b/lib/converters.js
@@ -25,15 +25,15 @@ function indent(content, spaces, ignoreFirst) {
     }).join("\n");
 }
 
-function parseTextFormat ( text ) {
+function parseTextFormat (text) {
     var formats = {
         strong: "**"
         ,italic: "*"
     };
-    var formated = text.replace(/\<\/?strong\>/gi, formats.strong );
-    formated = formated.replace(/\<\/?bold\>/gi, formats.strong );
-    formated = formated.replace(/\<\/?em\>/gi, formats.italic );
-    formated = formated.replace(/\<\/?italic\>/gi, formats.italic );
+    var formated = text.replace(/\<\/?strong\>/gi, formats.strong);
+    formated = formated.replace(/\<\/?bold\>/gi, formats.strong);
+    formated = formated.replace(/\<\/?em\>/gi, formats.italic);
+    formated = formated.replace(/\<\/?italic\>/gi, formats.italic);
     return formated;
 }
 
@@ -62,14 +62,14 @@ converters.img = function (input, json2md) {
 
 converters.ul = function (input, json2md) {
     for (var i = 0, c = ""; i < input.length; ++i) {
-        c += "\n - " + parseTextFormat( indent( json2md(input[i]), 4, true) );
+        c += "\n - " + parseTextFormat(indent(json2md(input[i]), 4, true));
     }
     return c + "\n";
 };
 
 converters.ol = function (input, json2md) {
     for (var i = 0, c = ""; i < input.length; ++i) {
-        c += "\n " + (i + 1) + ". " + parseTextFormat( indent( json2md(input[i]), 4, true) );
+        c += "\n " + (i + 1) + ". " + parseTextFormat(indent(json2md(input[i]), 4, true));
     }
     return c + "\n";
 };
@@ -86,5 +86,5 @@ converters.code = function (input, json2md) {
 };
 
 converters.p = function (input, json2md) {
-    return parseTextFormat( json2md(input, "\n") ) + "\n";
+    return parseTextFormat(json2md(input, "\n")) + "\n";
 };

--- a/lib/converters.js
+++ b/lib/converters.js
@@ -25,6 +25,22 @@ function indent(content, spaces, ignoreFirst) {
     }).join("\n");
 }
 
+function emphasisFormats( text ) {
+  return {
+    strong: '**',
+    italic: '*',
+  };
+}
+
+function parseTextFormat( text ) {
+  var formats = emphasisFormats();
+  var formated = text.replace(/\<\/?strong\>/gi, formats.strong );
+  formated = formated.replace(/\<\/?bold\>/gi, formats.strong );
+  formated = formated.replace(/\<\/?em\>/gi, formats.italic );
+  formated = formated.replace(/\<\/?italic\>/gi, formats.italic );
+  return formated;
+}
+
 // Headings
 converters.h1 = generateHeader(1);
 converters.h2 = generateHeader(2);
@@ -50,14 +66,14 @@ converters.img = function (input, json2md) {
 
 converters.ul = function (input, json2md) {
     for (var i = 0, c = ""; i < input.length; ++i) {
-        c += "\n - " + indent(json2md(input[i]), 4, true);
+        c += "\n - " + parseTextFormat( indent( json2md(input[i]), 4, true) );
     }
     return c + "\n";
 };
 
 converters.ol = function (input, json2md) {
     for (var i = 0, c = ""; i < input.length; ++i) {
-        c += "\n " + (i + 1) + ". " + indent(json2md(input[i]), 4, true);
+        c += "\n " + (i + 1) + ". " + parseTextFormat( indent( json2md(input[i]), 4, true) );
     }
     return c + "\n";
 };
@@ -74,5 +90,5 @@ converters.code = function (input, json2md) {
 };
 
 converters.p = function (input, json2md) {
-    return json2md(input, "\n") + "\n";
+    return parseTextFormat( json2md(input, "\n") ) + "\n";
 };

--- a/lib/converters.js
+++ b/lib/converters.js
@@ -25,20 +25,16 @@ function indent(content, spaces, ignoreFirst) {
     }).join("\n");
 }
 
-function emphasisFormats( text ) {
-  return {
-    strong: '**',
-    italic: '*',
-  };
-}
-
-function parseTextFormat( text ) {
-  var formats = emphasisFormats();
-  var formated = text.replace(/\<\/?strong\>/gi, formats.strong );
-  formated = formated.replace(/\<\/?bold\>/gi, formats.strong );
-  formated = formated.replace(/\<\/?em\>/gi, formats.italic );
-  formated = formated.replace(/\<\/?italic\>/gi, formats.italic );
-  return formated;
+function parseTextFormat ( text ) {
+    var formats = {
+        strong: "**"
+        ,italic: "*"
+    };
+    var formated = text.replace(/\<\/?strong\>/gi, formats.strong );
+    formated = formated.replace(/\<\/?bold\>/gi, formats.strong );
+    formated = formated.replace(/\<\/?em\>/gi, formats.italic );
+    formated = formated.replace(/\<\/?italic\>/gi, formats.italic );
+    return formated;
 }
 
 // Headings

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test"
+    "test": "node test"
   },
   "repository": {
     "type": "git",
@@ -21,10 +21,12 @@
     "generator"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
-  "contributors": [{
-    "name": "Crisoforo Gaspar",
-    "email": "github@crisoforo.com"
-  }],
+  "contributors": [
+    {
+      "name": "Crisoforo Gaspar",
+      "email": "github@crisoforo.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/json2md/issues"
@@ -39,6 +41,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "^2.3.3"
+    "tester": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json2md",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A JSON to Markdown converter.",
   "main": "lib/index.js",
   "directories": {
@@ -22,10 +22,7 @@
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "contributors": [
-    {
-      "name": "Crisoforo Gaspar",
-      "email": "github@crisoforo.com"
-    }
+    "Crisoforo Gaspar <github@crisoforo.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "generator"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [{
+    "name": "Crisoforo Gaspar",
+    "email": "github@crisoforo.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/json2md/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -1,171 +1,173 @@
 // Dependencies
 var json2md = require("../lib")
-  , Assert = require("assert")
+  , tester = require("tester")
   ;
 
-// Headings
-it("should support headings", function (cb) {
-    Assert.equal(json2md({ h1: "Heading 1" }), "# Heading 1");
-    Assert.equal(json2md({ h2: "Heading 2" }), "## Heading 2");
-    Assert.equal(json2md({ h3: "Heading 3" }), "### Heading 3");
-    Assert.equal(json2md({ h4: "Heading 4" }), "#### Heading 4");
-    Assert.equal(json2md({ h5: "Heading 5" }), "##### Heading 5");
-    Assert.equal(json2md({ h6: "Heading 6" }), "###### Heading 6");
-    cb();
-});
+tester.describe("json2md", test => {
+    // Headings
+    test.it("should support headings", function (cb) {
+        test.expect(json2md({ h1: "Heading 1" })).toBe("# Heading 1");
+        test.expect(json2md({ h2: "Heading 2" })).toBe("## Heading 2");
+        test.expect(json2md({ h3: "Heading 3" })).toBe("### Heading 3");
+        test.expect(json2md({ h4: "Heading 4" })).toBe("#### Heading 4");
+        test.expect(json2md({ h5: "Heading 5" })).toBe("##### Heading 5");
+        test.expect(json2md({ h6: "Heading 6" })).toBe("###### Heading 6");
+        cb();
+    });
 
-// Blockquote
-it("should support blockquotes", function (cb) {
-    Assert.equal(json2md({ blockquote: "Some content" }), "> Some content\n");
-    cb();
-});
+    // Blockquote
+    test.it("should support blockquotes", function (cb) {
+        test.expect(json2md({ blockquote: "Some content" })).toBe("> Some content\n");
+        cb();
+    });
 
-// Images
-it("should support images", function (cb) {
-    Assert.equal(json2md({
-        img: {
-            source: "source"
-          , title: "title"
-        }
-    }), "![title](source)\n");
-    cb();
-});
+    // Images
+    test.it("should support images", function (cb) {
+        test.expect(json2md({
+            img: {
+                source: "source"
+              , title: "title"
+            }
+        })).toBe("![title](source)\n");
+        cb();
+    });
 
-// Unordered lists
-it("should support unordered lists", function (cb) {
-    Assert.equal(json2md({
-        ul: [
-            "item 1"
-          , "item 2"
-        ]
-    }), "\n - item 1\n - item 2\n");
-    cb();
-});
-
-it("should support unordered lists with emphasis format", function (cb) {
-    Assert.equal(json2md({
-        ul: [
-            "<em>item 1</em>"
-          , "<bold>item 2</bold>"
-        ]
-    }), "\n - *item 1*\n - **item 2**\n");
-    cb();
-});
-
-// Ordered lists
-it("should support ordered lists", function (cb) {
-    Assert.equal(json2md({
-        ol: [
-            "item 1"
-          , "item 2"
-        ]
-    }), "\n 1. item 1\n 2. item 2\n");
-    cb();
-});
-
-// Code blocks
-it("should support code blocks", function (cb) {
-    Assert.equal(json2md({
-        code: {
-            language: "js"
-          , content: [
-              "function sum (a, b) {"
-            , "   return a + b;"
-            , "}"
-            , "sum(1, 2);"
+    // Unordered lists
+    test.it("should support unordered lists", function (cb) {
+        test.expect(json2md({
+            ul: [
+                "item 1"
+              , "item 2"
             ]
-        }
-    }), "```js\nfunction sum (a, b) {\n   return a + b;\n}\nsum(1, 2);\n```");
-    cb();
-});
+        })).toBe("\n - item 1\n - item 2\n");
+        cb();
+    });
 
-// Paragraphs
-it("should support paragraphs", function (cb) {
-    Assert.equal(json2md({
-        p: [
-            "Two"
-          , "Paragraphs"
-        ]
-    }), "\nTwo\n\nParagraphs\n");
-    cb();
-});
+    test.it("should support unordered lists with emphasis format", function (cb) {
+        test.expect(json2md({
+            ul: [
+                "<em>item 1</em>"
+              , "<bold>item 2</bold>"
+            ]
+        })).toBe("\n - *item 1*\n - **item 2**\n");
+        cb();
+    });
 
-it("should support paragraphs with bold text", function (cb) {
-    Assert.equal(json2md({
-        p: [
-            "Two <bold>more words</bold>"
-          , "in this paragraph, <strong>right?</strong>"
-        ]
-    }), "\nTwo **more words**\n\nin this paragraph, **right?**\n");
-    cb();
-});
+    // Ordered lists
+    test.it("should support ordered lists", function (cb) {
+        test.expect(json2md({
+            ol: [
+                "item 1"
+              , "item 2"
+            ]
+        })).toBe("\n 1. item 1\n 2. item 2\n");
+        cb();
+    });
 
-// Custom converters
-it("should support custom types", function (cb) {
-    json2md.converters.sayHello = function (input, json2md) {
-        return "Hello " + input + "!";
-    };
-    Assert.equal(json2md({ sayHello: "World" }), "Hello World!")
-    cb();
-});
+    // Code blocks
+    test.it("should support code blocks", function (cb) {
+        test.expect(json2md({
+            code: {
+                language: "js"
+              , content: [
+                  "function sum (a, b) {"
+                , "   return a + b;"
+                , "}"
+                , "sum(1, 2);"
+                ]
+            }
+        })).toBe("```js\nfunction sum (a, b) {\n   return a + b;\n}\nsum(1, 2);\n```");
+        cb();
+    });
 
-// Code blocks in lists
-it("should correctly indent code blocks in lists", function (cb) {
-    Assert.equal(json2md({
-        ol: [
-            [
-                "Copy the code below:",
-                {
-                    code: {
-                        language: "js"
-                      , content: [
-                          "function sum (a, b) {"
-                        , "   return a + b;"
-                        , "}"
-                        , "sum(1, 2);"
-                        ]
+    // Paragraphs
+    test.it("should support paragraphs", function (cb) {
+        test.expect(json2md({
+            p: [
+                "Two"
+              , "Paragraphs"
+            ]
+        })).toBe("\nTwo\n\nParagraphs\n");
+        cb();
+    });
+
+    test.it("should support paragraphs with bold text", function (cb) {
+        test.expect(json2md({
+            p: [
+                "Two <bold>more words</bold>"
+              , "in this paragraph, <strong>right?</strong>"
+            ]
+        })).toBe("\nTwo **more words**\n\nin this paragraph, **right?**\n");
+        cb();
+    });
+
+    // Custom converters
+    test.it("should support custom types", function (cb) {
+        json2md.converters.sayHello = function (input, json2md) {
+            return "Hello " + input + "!";
+        };
+        test.expect(json2md({ sayHello: "World" })).toBe("Hello World!")
+        cb();
+    });
+
+    // Code blocks in lists
+    test.it("should correctly indent code blocks in lists", function (cb) {
+        test.expect(json2md({
+            ol: [
+                [
+                    "Copy the code below:",
+                    {
+                        code: {
+                            language: "js"
+                          , content: [
+                              "function sum (a, b) {"
+                            , "   return a + b;"
+                            , "}"
+                            , "sum(1, 2);"
+                            ]
+                        }
                     }
-                }
+                ]
             ]
-        ]
-    }),
-`\n 1. Copy the code below:
+        })).toBe(`
+ 1. Copy the code below:
     \`\`\`js
     function sum (a, b) {
        return a + b;
     }
     sum(1, 2);
     \`\`\`
-`   )
-    cb();
-});
+`);
+        cb();
+    });
 
-it("should correctly indent code blocks in unordered lists", function (cb) {
-    Assert.equal(json2md({
-        ul: [
-            [
-                "Copy the code below:",
-                {
-                    code: {
-                        language: "js"
-                      , content: [
-                          "function sum (a, b) {"
-                        , "   return a + b;"
-                        , "}"
-                        , "sum(1, 2);"
-                        ]
+    test.it("should correctly indent code blocks in unordered lists", function (cb) {
+        test.expect(json2md({
+            ul: [
+                [
+                    "Copy the code below:",
+                    {
+                        code: {
+                            language: "js"
+                          , content: [
+                              "function sum (a, b) {"
+                            , "   return a + b;"
+                            , "}"
+                            , "sum(1, 2);"
+                            ]
+                        }
                     }
-                }
+                ]
             ]
-        ]
-    }),
-`\n - Copy the code below:
+        })).toBe(`
+ - Copy the code below:
     \`\`\`js
     function sum (a, b) {
        return a + b;
     }
     sum(1, 2);
     \`\`\`
-`   )
-    cb();
+`);
+        cb();
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,16 @@ it("should support unordered lists", function (cb) {
     cb();
 });
 
+it("should support unordered lists with emphasis format", function (cb) {
+    Assert.equal(json2md({
+        ul: [
+            "<em>item 1</em>"
+          , "<bold>item 2</bold>"
+        ]
+    }), "\n - *item 1*\n - **item 2**\n");
+    cb();
+});
+
 // Ordered lists
 it("should support ordered lists", function (cb) {
     Assert.equal(json2md({
@@ -77,6 +87,16 @@ it("should support paragraphs", function (cb) {
           , "Paragraphs"
         ]
     }), "\nTwo\n\nParagraphs\n");
+    cb();
+});
+
+it("should support paragraphs with bold text", function (cb) {
+    Assert.equal(json2md({
+        p: [
+            "Two <bold>more words</bold>"
+          , "in this paragraph, <strong>right?</strong>"
+        ]
+    }), "\nTwo **more words**\n\nin this paragraph, **right?**\n");
     cb();
 });
 


### PR DESCRIPTION
 - Add tags for emphasis format. Thanks @mitogh!
 - Using [`tester`](https://github.com/IonicaBizau/tester) instead of `mocha`.