### PR TITLE
support tables

### DIFF
--- a/lib/converters.js
+++ b/lib/converters.js
@@ -88,3 +88,21 @@ converters.code = function (input, json2md) {
 converters.p = function (input, json2md) {
     return parseTextFormat(json2md(input, "\n")) + "\n";
 };
+
+converters.table = function(input, json2md) {
+    if (typeof input != 'object') {
+        return '';
+    }
+    if (!input.hasOwnProperty('headers') || !input.hasOwnProperty('rows')) {
+        return '';
+    }
+    var header = input.headers.join(' | ');
+    var spaces = input.headers.map(function() { return '---'; }).join(' | ');
+    var data  = input.rows.map(function(r) {
+        return input.headers.map(function(h) {
+            return parseTextFormat(json2md(r[h] ? r[h] + "" : ""));
+        }).join(' | ');
+    }).join('\n');
+
+    return [header, spaces, data].join('\n');
+};

--- a/lib/converters.js
+++ b/lib/converters.js
@@ -99,9 +99,15 @@ converters.table = function(input, json2md) {
     var header = input.headers.join(' | ');
     var spaces = input.headers.map(function() { return '---'; }).join(' | ');
     var data  = input.rows.map(function(r) {
-        return input.headers.map(function(h) {
-            return parseTextFormat(json2md(r[h] ? r[h] + "" : ""));
-        }).join(' | ');
+        if (Array.isArray(r)) {
+            return r.map(function(el) {
+                return parseTextFormat(json2md(el));
+            }).join(' | ');
+        } else {
+            return input.headers.map(function(h) {
+                return parseTextFormat(json2md(r[h]));
+            }).join(' | ');
+        }
     }).join('\n');
 
     return [header, spaces, data].join('\n');

--- a/test/index.js
+++ b/test/index.js
@@ -171,13 +171,25 @@ tester.describe("json2md", test => {
         cb();
     });
 
-    test.it('should support tables', function(cb) {
+    test.it('should support tables, rows is objects', function(cb) {
         test.expect(json2md({
             table: {
                 headers: ['a', 'b']
-              , rows: [{a:1, b:2}]
+              , rows: [{a:'col1', b:'col2'}]
             }
-        })).toBe("a | b\n--- | ---\n1 | 2");
+        })).toBe("a | b\n--- | ---\ncol1 | col2");
+        cb();
+    })
+
+    test.it('should support tables, rows is arrays', function(cb) {
+        test.expect(json2md({
+            table: {
+                headers: ['a', 'b']
+              , rows: [
+                    ['col1', 'col2']
+                ]
+            }
+        })).toBe("a | b\n--- | ---\ncol1 | col2");
         cb();
     })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -170,4 +170,14 @@ tester.describe("json2md", test => {
 `);
         cb();
     });
+
+    test.it('should support tables', function(cb) {
+        test.expect(json2md({
+            table: {
+                headers: ['a', 'b']
+              , rows: [{a:1, b:2}]
+            }
+        })).toBe("a | b\n--- | ---\n1 | 2");
+        cb();
+    })
 });


### PR DESCRIPTION
This patch added support tables. Example:

```js
json2md({
    table: {
        headers: [ "a",  "b" ],
        rows: [
            { a: 'row1, col1' ,  b: 'row1, col2' }
        ]
    }
})
```