### PR TITLE
Fix error when input is number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ var converters = require("./converters");
  */
 function json2md(data, prefix, _type) {
     prefix = prefix || "";
-    if (typeof data === "string") {
+    if (typeof data === "string" || typeof data === 'number') {
         return prefix + data;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -170,4 +170,10 @@ tester.describe("json2md", test => {
 `);
         cb();
     });
+
+    test.it("should work when input is number", function (cb) {
+        test.expect(json2md({ blockquote: 123 })).toBe("> 123\n");
+        cb();
+    });
+
 });


### PR DESCRIPTION
If input data is number, then app crached with error:

```
Error: There is no such converter: undefined
```

Numbers should be processed as strings.