### PR TITLE
fix: add backtick in readme's link element

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Converts a JSON input to markdown.
 | `ol`         | Ordered list       | An array of strings or lists representing the items.                                                                             | `{ ol: ["item 1", "item 2"] }`                                                                                                                   |
 | `code`       | Code block element | An object containing the `language` (`String`) and `content` (`Array` or `String`)  fields.                              | `{ code: { "language": "html", "content": "<script src='dummy.js'></script>" } }`                                                                |
 | `table`      | Table              | An object containing the `headers` (`Array` of `String`s) and `rows` (`Array` of `Array`s or `Object`s).                 | `{ table: { headers: ["a", "b"], rows: [{ a: "col1", b: "col2" }] } }` or `{ table: { headers: ["a", "b"], rows: [["col1", "col2"]] } }`         |
-| `link`       | Link               | An object containing the `title` and the `source` fields.                                                                | `{ title: 'hello', source: 'https://ionicabizau.net' }
+| `link`       | Link               | An object containing the `title` and the `source` fields.                                                                | `{ title: 'hello', source: 'https://ionicabizau.net' }`
 
 You can extend the `json2md.converters` object to support your custom types.
 


### PR DESCRIPTION
Hi there! 👋🏽 

Thank you so much for creating this library, it's awesome! 😊 

I have been using the library and looking at the `README.md` docs and seems like a backtick is missing on the link element. 

Hope this fixes it 😉 