### PR TITLE
Fix md on table with more than one row

### DIFF
--- a/lib/converters.js
+++ b/lib/converters.js
@@ -148,17 +148,50 @@ converters.table = (input, json2md) => {
         header.length - 2
     ))
 
-    // add spaces around column name if necessary (side(s) depends on alignment)
-    const column_names = input.headers.map((header, index) => {
+    if (input.pretty === true) {
+        // update preferred_lengths considering rows' cells length
+        input.rows.forEach(row => {
+            (Array.isArray(row) ? row : input.headers.map(col_id => row[col_id]))
+                .forEach((cell, index) => {
+                    preferred_lengths[index] = Math.max(preferred_lengths[index], cell.length-2)
+                })
+        })
+    }
+
+    const fill_right = function(diff, header) {
+        return " ".repeat(diff) + header;
+    }
+    const fill_left = function(diff, header) {
+        return header + " ".repeat(diff);
+    }
+    const fill_center = function(diff, header) {
+        return " ".repeat(Math.floor(diff/2)) + header + " ".repeat(Math.ceil(diff/2));
+    }
+
+    const fill_th = (header, index) => {
         const diff = preferred_lengths[index]+2 - header.length;
         switch (alignment[index]) {
-            case ALIGNMENT.RIGHT:   return " ".repeat(diff) + header;
-            case ALIGNMENT.LEFT:    return header + " ".repeat(diff);
+            case ALIGNMENT.RIGHT:   return fill_right(diff, header);
+            case ALIGNMENT.LEFT:    return fill_left(diff, header);
             case ALIGNMENT.CENTER:
             case ALIGNMENT.NONE:
-            default:                return " ".repeat(Math.floor(diff/2)) + header + " ".repeat(Math.ceil(diff/2));
+            default:                return fill_center(diff, header);
         }
-    })
+    };
+
+    const fill_td = (header, index) => {
+        const diff = preferred_lengths[index]+2 - header.length;
+        switch (alignment[index]) {
+            case ALIGNMENT.RIGHT:   return fill_right(diff, header);
+            case ALIGNMENT.NONE:
+            case ALIGNMENT.LEFT:    return fill_left(diff, header);
+            case ALIGNMENT.CENTER:
+            default:                return fill_center(diff, header);
+        }
+    };
+
+    // add spaces around column name if necessary (side(s) depends on alignment)
+    const column_names = input.headers.map(fill_th)
 
     const header = "| " + column_names.join(" | ") + " |";
 
@@ -173,11 +206,17 @@ converters.table = (input, json2md) => {
         }
     }).join(" | ") + " |";
 
+    const fill_tbody_cell = (cell, index) => {
+        if(input.pretty !== true) return cell;
+        return fill_td(cell, index);
+    }
+
     const data  = input.rows.map(row =>
         "| " + (Array.isArray(row) ? row : input.headers.map(col_id => row[col_id]))
             .map(cell => json2md(cell))
             .map(cell => parseTextFormat(cell))
             .map(cell => cell.replace(/([^\\])\|/, "$1\\|"))
+            .map(fill_tbody_cell)
             .join(" | ")  + " |"
     ).join("\n");
 

--- a/lib/converters.js
+++ b/lib/converters.js
@@ -173,13 +173,13 @@ converters.table = (input, json2md) => {
         }
     }).join(" | ") + " |";
 
-    const data  = "| " + input.rows.map(row =>
-        (Array.isArray(row) ? row : input.headers.map(col_id => row[col_id]))
+    const data  = input.rows.map(row =>
+        "| " + (Array.isArray(row) ? row : input.headers.map(col_id => row[col_id]))
             .map(cell => json2md(cell))
             .map(cell => parseTextFormat(cell))
             .map(cell => cell.replace(/([^\\])\|/, "$1\\|"))
-            .join(" | ")
-    ).join("\n") + " |";
+            .join(" | ")  + " |"
+    ).join("\n");
 
     return [header, spaces, data].join("\n")
 }

--- a/test/index.js
+++ b/test/index.js
@@ -228,9 +228,12 @@ tester.describe("json2md", test => {
                 rows: [{
                     a: "col1",
                     b: "col2"
+                }, {
+                    a: "col1",
+                    b: "col2"
                 }]
             }
-        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n");
+        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n| col1 | col2 |\n");
         cb();
     })
 
@@ -239,10 +242,11 @@ tester.describe("json2md", test => {
             table: {
                 headers: ["a", "b"],
                 rows: [
+                    ["col1", "col2"],
                     ["col1", "col2"]
                 ]
             }
-        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n");
+        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n| col1 | col2 |\n");
         cb();
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -230,10 +230,10 @@ tester.describe("json2md", test => {
                     b: "col2"
                 }, {
                     a: "col1",
-                    b: "col2"
+                    b: "col2 very long"
                 }]
             }
-        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n| col1 | col2 |\n");
+        })).toBe("|  a  |  b  |\n| --- | --- |\n| col1 | col2 |\n| col1 | col2 very long |\n");
         cb();
     })
 
@@ -287,6 +287,65 @@ tester.describe("json2md", test => {
         })).toBe("|  a  |  b  |\n| --- | --- |\n| col\\|1 | col\\|2 |\n");
         cb();
     })
+
+    test.it("should support pretty tables, rows is objects", function(cb) {
+        test.expect(json2md({
+            table: {
+                pretty: true,
+                headers: ["a", "b"],
+                rows: [{
+                    a: "col1",
+                    b: "col2"
+                }, {
+                    a: "col1",
+                    b: "col2 very long"
+                }]
+            }
+        })).toBe(`|  a   |       b        |
+| ---- | -------------- |
+| col1 | col2           |
+| col1 | col2 very long |
+`);
+        cb();
+    })
+
+    test.it("should support pretty tables, rows is array", function(cb) {
+        test.expect(json2md({
+            table: {
+                pretty: true,
+                headers: ["a", "b"],
+                rows: [
+                    ["col1", "col2"],
+                    ["col1", "col2 very long"]
+                ]
+            }
+        })).toBe(`|  a   |       b        |
+| ---- | -------------- |
+| col1 | col2           |
+| col1 | col2 very long |
+`);
+        cb();
+    })
+
+    test.it("should support pretty tables aligns", function(cb) {
+        test.expect(json2md({
+            table: {
+                pretty: true,
+                aligns: ['left', 'right'],
+                headers: ["a", "b"],
+                rows: [
+                    ["col1", "col2"],
+                    ["col1", "col2 very long"]
+                ]
+            }
+        })).toBe(`| a    |              b |
+| :--- | -------------: |
+| col1 |           col2 |
+| col1 | col2 very long |
+`);
+        cb();
+    })
+
 });
 
 tester.describe("json2md.async", test => {


### PR DESCRIPTION
Hi,
this commit fix a wrong behavior when table has more than one row.

This is the current rendering:

```
|  a  |  b  |
| --- | --- |
| col1 | col2
col1 | col2 |
```

while the desired one is

```
|  a  |  b  |
| --- | --- |
| col1 | col2 |
| col1 | col2 |
```