### PR TITLE
Add support for complex top-level objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,13 +64,17 @@ function json2md(data, prefix, _type) {
         }
         return content.join("\n")
     } else {
-        let type = Object.keys(data)[0]
-          , func = converters[_type || type]
+    	let mdText = "";
+        Object.keys(data).forEach((type, index, array) => {
+           	let func = converters[_type || type];
 
-        if (typeof func === "function") {
-            return indento(func(_type ? data : data[type], json2md), 1, prefix) + "\n"
-        }
-        throw new Error("There is no such converter: " + type)
+	        if (typeof func === "function") {
+    	        mdText += indento(func(_type ? data : data[type], json2md), 1, prefix) + "\n";
+        	} else {
+	        	throw new Error("There is no such converter: " + type);
+	        }
+        });
+        return mdText;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Dmitry Tsvettsikh <me@reklatsmasters.com>",
     "Daniel Bastos <danielbastos@live.com>",
     "Keith Chen <keith.chenzhun@yahoo.com>",
-    "Cédric Delpoux <cedric.delpoux@gmail.com>"
+    "Cédric Delpoux <cedric.delpoux@gmail.com>",
+    "Jan-Philipp Steghöfer <gh@splashstudio.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/test/index.js
+++ b/test/index.js
@@ -355,6 +355,19 @@ tester.describe("json2md", test => {
 `);
         cb();
     })
+    
+    test.it("should support several top-level object keys",
+    	function(cb) {
+			json2md.converters.sayHello = function(input, json2md) {
+				return "Hello " + input + "!";
+			};
+			test.expect(json2md({
+				sayHello: "World",
+				h1: "Hello Friends!"
+			})).toBe("Hello World!\n# Hello Friends!\n")
+			cb();
+    	}
+    );
 
 });
 


### PR DESCRIPTION
Previously, json2md only accessed the first element of the top-level
object in the JSON file. That is fine if the JSON file follows a
strictly hierarchical structure (as in the HTML examples), but fails
if there is a more complex structure.
This commit changes this behaviour (at least for the synchronous part)
and now traverses all object keys at the top level, concatenating the
results as we go along.