### PR TITLE
Add test to demonstrate img array bug

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,27 @@ tester.describe("json2md", test => {
         cb();
     });
 
+    // Image array
+    test.it("should support an array of images", function(cb) {
+        test.expect(json2md({
+            img:[{
+                source: "source",
+                title: "title",
+                alt: 'alt',
+            }, {
+                source: "sauce",
+                title: "heading",
+                alt: 'salt',
+            }]
+        })).toBe([
+            '![alt](source "title")',
+            '',
+            '![salt](sauce "heading")',
+            '',
+        ].join('\n'));
+        cb();
+    });
+
     // Links
     test.it("should support links", function(cb) {
         test.expect(json2md({


### PR DESCRIPTION
See: https://github.com/IonicaBizau/json2md/issues/97

```
> json2md@2.0.0 test
> node test

  ➡️ json2md
     ⚡ should support headings
     ⚡ should support blockquotes
     ⚡ should support images
     ❌ should support an array of images
     Error: Expected '![alt](source "title")\n![alt](source "title")\n![alt](source "title")\n\n![salt](sauce "heading")\n![salt](sauce "heading")\n![salt](sauce "heading")\n\n' to be '![alt](source "title")\n\n![salt](sauce "heading")\n'
         at assert (/Users/john/Local/json2md/node_modules/expect/lib/assert.js:29:9)
         at Expectation.toBe (/Users/john/Local/json2md/node_modules/expect/lib/Expectation.js:66:28)
         at Object.<anonymous> (/Users/john/Local/json2md/test/index.js:61:13)
         at Domain.<anonymous> (/Users/john/Local/json2md/node_modules/tester/lib/index.js:161:24)
         at Domain.run (node:domain:389:15)
         at module.exports (/Users/john/Local/json2md/node_modules/try-async/lib/index.js:18:5)
         at _fn (/Users/john/Local/json2md/node_modules/tester/lib/index.js:160:17)
         at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
 ```
 
 TODO: Figure out why images are duplicated when presented as an array. This PR provides test coverage.